### PR TITLE
Preparations for 1.13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /bin
 /dist
 /manifest.mf
+/*.bat
 
 /world
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.shininet.bukkit</groupId>
     <artifactId>PlayerHeads</artifactId>
     <packaging>jar</packaging>
-    <version>3.12</version>
+    <version>3.12.1</version>
     <name>PlayerHeads</name>
 
     <organization>
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <version>1.13.1-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <version>1.13.1-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>fr.neatmonster</groupId>

--- a/src/main/java/com/github/crashdemons/playerheads/VanillaSkullType.java
+++ b/src/main/java/com/github/crashdemons/playerheads/VanillaSkullType.java
@@ -30,6 +30,8 @@ public enum VanillaSkullType {//deprecated in api, but we stll need to keep trac
     }
 
     VanillaSkullType(Material mat, Material wallMat){
+        material=mat;
+        wallMaterial=wallMat;
         Mappings.skullTypeByMaterial.put(mat, this);
         Mappings.skullTypeByMaterial.put(wallMat, this);
     }

--- a/src/main/java/com/github/crashdemons/playerheads/VanillaSkullType.java
+++ b/src/main/java/com/github/crashdemons/playerheads/VanillaSkullType.java
@@ -1,0 +1,61 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.crashdemons.playerheads;
+
+import java.util.HashMap;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ *
+ * @author crash
+ */
+public enum VanillaSkullType {//deprecated in api, but we stll need to keep track of vanilla heads, and there is no method for checking isSkull or isHead in the api...
+    CREEPER(Material.CREEPER_HEAD,Material.CREEPER_WALL_HEAD),	
+    DRAGON(Material.DRAGON_HEAD,Material.DRAGON_WALL_HEAD),
+    PLAYER(Material.PLAYER_HEAD,Material.PLAYER_WALL_HEAD),
+    SKELETON(Material.SKELETON_SKULL,Material.SKELETON_WALL_SKULL),	
+    WITHER(Material.WITHER_SKELETON_SKULL,Material.WITHER_SKELETON_WALL_SKULL),
+    ZOMBIE(Material.ZOMBIE_HEAD,Material.ZOMBIE_WALL_HEAD);
+
+    private Material material;
+    private Material wallMaterial;
+
+    private static class Mappings{
+        public static HashMap<Material,VanillaSkullType> skullTypeByMaterial = new HashMap<>();
+    }
+
+    VanillaSkullType(Material mat, Material wallMat){
+        Mappings.skullTypeByMaterial.put(mat, this);
+        Mappings.skullTypeByMaterial.put(wallMat, this);
+    }
+
+    public Material getMaterial(){
+        return material;
+    }
+    public static VanillaSkullType fromMaterial(Material mat){
+        return Mappings.skullTypeByMaterial.get(mat);
+    }
+    public static Material toMaterial(VanillaSkullType type){
+        return type.getMaterial();
+    }
+    public static boolean hasMaterial(Material mat){
+        return Mappings.skullTypeByMaterial.containsKey(mat);
+    }
+    public static boolean hasItem(ItemStack stack){
+        return hasMaterial(stack.getType());
+    }
+    public static boolean hasBlock(Block block){
+        return hasMaterial(block.getType());
+    }
+    public static VanillaSkullType fromItem(ItemStack stack){
+        return fromMaterial(stack.getType() );
+    }
+    public static VanillaSkullType fromBlock(Block block){
+        return fromMaterial(block.getType() );
+    }
+}

--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsCommandExecutor.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsCommandExecutor.java
@@ -4,6 +4,7 @@
 
 package org.shininet.bukkit.playerheads;
 
+import com.github.crashdemons.playerheads.VanillaSkullType;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -196,7 +197,7 @@ class PlayerHeadsCommandExecutor implements CommandExecutor, TabCompleter {
                 return true;
             }
             ItemStack skullInput = ((Player) sender).getEquipment().getItemInMainHand();
-            if (skullInput.getType() != Material.SKULL_ITEM) {
+            if (!VanillaSkullType.hasItem(skullInput)) {
                 Tools.formatMsg(sender, Lang.BRACKET_LEFT + label + Lang.COLON + Lang.CMD_RENAME + Lang.BRACKET_RIGHT + Lang.SPACE + Lang.ERROR_NOT_A_HEAD);
                 return true;
             }

--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
@@ -4,6 +4,7 @@
 
 package org.shininet.bukkit.playerheads;
 
+import com.github.crashdemons.playerheads.VanillaSkullType;
 import java.util.List;
 import java.util.Random;
 
@@ -33,6 +34,7 @@ import org.shininet.bukkit.playerheads.events.PlayerDropHeadEvent;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.hooks.NCPExemptionManager;
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
 
 /**
  * @author meiskam
@@ -90,7 +92,7 @@ class PlayerHeadsListener implements Listener {
                 return;
             }
 
-            if (plugin.configFile.getBoolean("antideathchest") || Boolean.valueOf(player.getWorld().getGameRuleValue("keepInventory"))) {
+            if (plugin.configFile.getBoolean("antideathchest") || player.getWorld().getGameRuleValue(GameRule.KEEP_INVENTORY)) {
                 Location location = player.getLocation();
                 location.getWorld().dropItemNaturally(location, drop);
             } else {
@@ -123,27 +125,27 @@ class PlayerHeadsListener implements Listener {
                 }
             }
         } else if (entityType == EntityType.CREEPER) {
-            EntityDeathHelper(event, SkullType.CREEPER, plugin.configFile.getDouble("creeperdroprate") * lootingrate);
+            EntityDeathHelper(event, VanillaSkullType.CREEPER, plugin.configFile.getDouble("creeperdroprate") * lootingrate);
         } else if (entityType == EntityType.ZOMBIE) {
-            EntityDeathHelper(event, SkullType.ZOMBIE, plugin.configFile.getDouble("zombiedroprate") * lootingrate);
-        } else if (entityType == EntityType.SKELETON) {
+            EntityDeathHelper(event, VanillaSkullType.ZOMBIE, plugin.configFile.getDouble("zombiedroprate") * lootingrate);
+        } else if (entityType == EntityType.SKELETON || entityType == EntityType.WITHER_SKELETON || entityType == EntityType.STRAY) {//I changed this because entitytype is now distinct for all types of skeleton
             if (event.getEntity() instanceof Stray) {
                 EntityDeathHelper(event, CustomSkullType.STRAY, plugin.configFile.getDouble("straydroprate") * lootingrate);
             } else if (event.getEntity() instanceof WitherSkeleton) {
                 if (plugin.configFile.getDouble("witherdroprate") < 0) {
                     return;
                 }
-                event.getDrops().removeIf(itemStack -> itemStack.getType() == Material.SKULL_ITEM);
-                EntityDeathHelper(event, SkullType.WITHER, plugin.configFile.getDouble("witherdroprate") * lootingrate);
+                event.getDrops().removeIf(itemStack -> itemStack.getType() == Material.WITHER_SKELETON_SKULL);
+                EntityDeathHelper(event, VanillaSkullType.WITHER, plugin.configFile.getDouble("witherdroprate") * lootingrate);
             } else if (event.getEntity() instanceof Skeleton) {
-                EntityDeathHelper(event, SkullType.SKELETON, plugin.configFile.getDouble("skeletondroprate") * lootingrate);
+                EntityDeathHelper(event, VanillaSkullType.SKELETON, plugin.configFile.getDouble("skeletondroprate") * lootingrate);
             }
         } else if (entityType == EntityType.SLIME) {
             if (((Slime) event.getEntity()).getSize() == 1) {
                 EntityDeathHelper(event, CustomSkullType.SLIME, plugin.configFile.getDouble("slimedroprate") * lootingrate);
             }
         } else if (entityType == EntityType.ENDER_DRAGON) {
-            EntityDeathHelper(event, SkullType.DRAGON, plugin.configFile.getDouble("enderdragondroprate") * lootingrate);
+            EntityDeathHelper(event, VanillaSkullType.DRAGON, plugin.configFile.getDouble("enderdragondroprate") * lootingrate);
         } else {
             try {
                 CustomSkullType customSkullType = CustomSkullType.valueOf(entityType.name());
@@ -166,8 +168,8 @@ class PlayerHeadsListener implements Listener {
 
         ItemStack drop;
 
-        if (type instanceof SkullType) {
-            drop = Tools.Skull((SkullType) type);
+        if (type instanceof VanillaSkullType) {
+            drop = Tools.Skull((VanillaSkullType) type);
         } else if (type instanceof CustomSkullType) {
             drop = Tools.Skull((CustomSkullType) type);
         } else {
@@ -193,10 +195,10 @@ class PlayerHeadsListener implements Listener {
     public void onPlayerInteract(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
         Player player = event.getPlayer();
-        if (block != null && block.getType() == Material.SKULL) {
+        if (block != null && VanillaSkullType.hasBlock(block) ) {
             Skull skullState = (Skull) block.getState();
             if (player.hasPermission("playerheads.clickinfo")) {
-                switch (skullState.getSkullType()) {
+                switch (VanillaSkullType.fromBlock(block)) {
                     case PLAYER:
                         if (skullState.hasOwner()) {
                             String owner = skullState.getOwningPlayer().getName();
@@ -228,7 +230,7 @@ class PlayerHeadsListener implements Listener {
                         Tools.formatMsg(player, Lang.CLICKINFO2, Tools.format(Lang.HEAD_ZOMBIE));
                         break;
                 }
-            } else if ((skullState.getSkullType() == SkullType.PLAYER) && (skullState.hasOwner())) {
+            } else if ((VanillaSkullType.fromBlock(block) == VanillaSkullType.PLAYER) && (skullState.hasOwner())) {
                 String owner = skullState.getOwningPlayer().toString();
                 CustomSkullType skullType = CustomSkullType.get(owner);
                 if ((skullType != null) && (!owner.equals(skullType.getOwner()))) {
@@ -246,7 +248,7 @@ class PlayerHeadsListener implements Listener {
         }
         Block block = event.getBlock();
         Player player = event.getPlayer();
-        if ((player.getGameMode() != GameMode.CREATIVE) && (block.getType() == Material.SKULL)) {
+        if ((player.getGameMode() != GameMode.CREATIVE) && VanillaSkullType.hasBlock(block)) {
             Skull skull = (Skull) block.getState();
             if (skull.hasOwner()) {
                 //String owner = ChatColor.stripColor(skull.getOwner()); //Unnecessary?

--- a/src/main/java/org/shininet/bukkit/playerheads/Tools.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/Tools.java
@@ -4,11 +4,11 @@
 
 package org.shininet.bukkit.playerheads;
 
+import com.github.crashdemons.playerheads.VanillaSkullType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.SkullType;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -69,13 +69,13 @@ public class Tools {
         }
 
         if (skullOwnerLC.equals(Lang.HEAD_SPAWN_CREEPER)) {
-            return Skull(SkullType.CREEPER, quantity);
+            return Skull(VanillaSkullType.CREEPER, quantity);
         } else if (skullOwnerLC.equals(Lang.HEAD_SPAWN_ZOMBIE)) {
-            return Skull(SkullType.ZOMBIE, quantity);
+            return Skull(VanillaSkullType.ZOMBIE, quantity);
         } else if (skullOwnerLC.equals(Lang.HEAD_SPAWN_SKELETON)) {
-            return Skull(SkullType.SKELETON, quantity);
+            return Skull(VanillaSkullType.SKELETON, quantity);
         } else if (skullOwnerLC.equals(Lang.HEAD_SPAWN_WITHER)) {
-            return Skull(SkullType.WITHER, quantity);
+            return Skull(VanillaSkullType.WITHER, quantity);
         } else {
             return Skull(skullOwner, null, quantity);
         }
@@ -87,7 +87,7 @@ public class Tools {
     }
 
     public static ItemStack Skull(String skullOwner, String displayName, int quantity) {
-        ItemStack skull = new ItemStack(Material.SKULL_ITEM, quantity, (short) SkullType.PLAYER.ordinal());
+        ItemStack skull = new ItemStack(Material.PLAYER_HEAD, quantity);
         SkullMeta skullMeta = (SkullMeta) skull.getItemMeta();
         boolean shouldSet = false;
         if ((skullOwner != null) && (!skullOwner.equals(""))) {
@@ -112,12 +112,12 @@ public class Tools {
         return Skull(type.getOwner(), type.getDisplayName(), quantity);
     }
 
-    public static ItemStack Skull(SkullType type) {
+    public static ItemStack Skull(VanillaSkullType type) {
         return Skull(type, Config.defaultStackSize);
     }
 
-    public static ItemStack Skull(SkullType type, int quantity) {
-        return new ItemStack(Material.SKULL_ITEM, quantity, (short) type.ordinal());
+    public static ItemStack Skull(VanillaSkullType type, int quantity) {
+        return new ItemStack(type.getMaterial(), quantity);
     }
 
     public static String format(String text, String... replacement) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,8 @@ version: ${project.version}
 description: Drops a player's head when s/he dies, also mob heads
 authors: [meiskam, zand]
 
+api-version: 1.13
+
 main: org.shininet.bukkit.playerheads.PlayerHeads
 database: false
 


### PR DESCRIPTION
Removes references to the old SkullType and SKULL_ITEM and datavalues in lieu of vanilla head items - but provides a class to continue tracking which vanilla heads are supported without deprecation warnings.

Curiously though with the 1.13 API,  `skullState.getOwningPlayer().getName()` can now return null even when an owner is set, where `skullState.getOwner()` returns the real name tag - so unfortunately I had to reintroduce a deprecated call without any good alternatives available. (maybe you have a suggestion here?)

Additionally I added some NPE protection concerning clicking custom [textured] heads that have profile fields but no names.

This **does not** add mobs or features to the plugin - but at least this builds and runs with spigot for me, I was able to test interaction with various head types, block-break spawning, and command spawning, and mob drops.

This is an intentionally minimal change to get the plugin running/building under 1.13+.  I have a [much larger conversion finished](https://github.com/crashdemons/PlayerHeads/tree/master) that adds a few things and makes changes (textured heads, all mobs), but I figured there wasn't much chance of PRing that big of a change.   If you're feeling adventurous and you would rather me PR my 4.x branch instead, let me know. (3.x-min is not an ancestor of it though)
